### PR TITLE
Fix/issue-50: use major version tag in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: builder
-FROM golang:1.10.3-stretch as builder
+FROM golang:1.10-stretch as builder
 
 WORKDIR /go/src/github.com/CovenantSQL/CovenantSQL
 COPY . .


### PR DESCRIPTION
Fixes #50. Since golang 1.10.4 is released and image tag 1.10.3-stretch is removed, it's suggested that we should use a major version tag to build docker image.