### PR TITLE
Support hole skipping in observer

### DIFF
--- a/cmd/observer/service.go
+++ b/cmd/observer/service.go
@@ -383,12 +383,12 @@ func (s *Service) addAckedQuery(dbID proto.DatabaseID, ack *wt.SignedAckHeader) 
 }
 
 func (s *Service) addBlock(dbID proto.DatabaseID, b *ct.Block) (err error) {
-	log.Debugf("add block %v, %v -> %v, %v", dbID, b.BlockHash(), b.ParentHash(), b.Producer())
-
 	instance, err := s.getUpstream(dbID)
 	h := int32(b.Timestamp().Sub(instance.GenesisBlock.Timestamp()) / blockProducePeriod)
 	key := heightToBytes(h)
 	key = append(key, b.BlockHash().CloneBytes()...)
+
+	log.Debugf("add block %v, height: %v, %v -> %v, %v", dbID, h, b.BlockHash(), b.ParentHash(), b.Producer())
 
 	return s.db.Update(func(tx *bolt.Tx) (err error) {
 		bb, err := tx.Bucket(blockBucket).CreateBucketIfNotExists([]byte(dbID))

--- a/sqlchain/observer.go
+++ b/sqlchain/observer.go
@@ -64,6 +64,8 @@ func newObserverReplicator(nodeID proto.NodeID, startHeight int32, c *Chain) *ob
 func (r *observerReplicator) setNewHeight(newHeight int32) {
 	r.replLock.Lock()
 	defer r.replLock.Unlock()
+
+	r.height = newHeight
 }
 
 func (r *observerReplicator) stop() {
@@ -111,7 +113,64 @@ func (r *observerReplicator) replicate() {
 		return
 	} else if block == nil {
 		log.Debugf("no block of height %v for observer %v", r.height, r.nodeID)
-		return
+
+		// black hole in chain?
+		// find last available block
+		log.Debug("start block height hole detection")
+
+		var lastBlock, nextBlock *ct.Block
+		var lastHeight, nextHeight int32
+
+		for h := r.height - 1; h >= 0; h-- {
+			if lastBlock, err = r.c.FetchBlock(h); err == nil && lastBlock != nil {
+				lastHeight = h
+				log.Debugf("found last available block %v with height %v",
+					lastBlock.BlockHash().String(), lastHeight)
+				break
+			}
+		}
+
+		if lastBlock == nil {
+			// could not find last available block, this should be a fatal issue
+			log.Warning("could not found last available block during hole detection")
+			return
+		}
+
+		// find next available block
+		for h := r.height + 1; h <= curHeight; h++ {
+			if nextBlock, err = r.c.FetchBlock(h); err == nil && nextBlock != nil {
+				if !nextBlock.ParentHash().IsEqual(lastBlock.BlockHash()) {
+					// inconsistency
+					log.Warningf("inconsistency detected during hole detection, "+
+						"last block height: %v, hash: %v, next block height: %v, hash: %v, parent hash: %v",
+						lastBlock.BlockHash().String(), lastHeight,
+						nextBlock.BlockHash().String(), h, nextBlock.ParentHash().String())
+
+					return
+				}
+
+				nextHeight = h
+				log.Debugf("found next available block %v with height %v",
+					nextBlock.BlockHash().String(), nextHeight)
+				break
+			}
+		}
+
+		if nextBlock == nil {
+			// could not find next available block, try next time
+			log.Debug("could not found next available block during hole detection")
+			return
+		}
+
+		// successfully found a hole in chain
+		log.Debugf("found a hole in chain, started with block: %v, height: %v to block: %v, height: %v, skipped %v blocks",
+			lastBlock.BlockHash().String(), lastHeight, nextBlock.BlockHash().String(), nextHeight, nextHeight-lastHeight-1)
+
+		r.height = nextHeight
+		block = nextBlock
+
+		log.Debugf("finish block height hole detection, skipping to block: %v, height: %v",
+			block.BlockHash().String(), r.height)
 	}
 
 	// fetch acks in block


### PR DESCRIPTION
SQLChain could produce inconsecutive heights of blocks after a system crash recovery or having a long time packing transactions in the last block producing period.
This request contains detection logic for this abnormal condition and skips the empty blocks during block replication.