### PR TITLE
Update Dockerfile, using go1.11 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: builder
-FROM golang:1.10-stretch as builder
+FROM golang:1.11-stretch as builder
 
 WORKDIR /go/src/github.com/CovenantSQL/CovenantSQL
 COPY . .


### PR DESCRIPTION
Update Dockerfile, using go1.11 instead