### PR TITLE
Format code for new version goimports

### DIFF
--- a/blockproducer/chain.go
+++ b/blockproducer/chain.go
@@ -34,7 +34,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/rpc"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/pkg/errors"
 )
 

--- a/blockproducer/metaindex.go
+++ b/blockproducer/metaindex.go
@@ -23,7 +23,7 @@ import (
 	pt "github.com/CovenantSQL/CovenantSQL/blockproducer/types"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/utils"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/ulule/deepcopier"
 )
 

--- a/blockproducer/metaindex_test.go
+++ b/blockproducer/metaindex_test.go
@@ -24,7 +24,7 @@ import (
 	pi "github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
 	pt "github.com/CovenantSQL/CovenantSQL/blockproducer/types"
 	"github.com/CovenantSQL/CovenantSQL/proto"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/blockproducer/metastate.go
+++ b/blockproducer/metastate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"github.com/ulule/deepcopier"
 )
 
@@ -84,7 +84,7 @@ func (s *metaState) loadAccountStableBalance(addr proto.AccountAddress) (b uint6
 			"loaded":  loaded,
 		}).Debug("queried stable account")
 	}()
-	
+
 	s.Lock()
 	defer s.Unlock()
 

--- a/blockproducer/metastate_test.go
+++ b/blockproducer/metastate_test.go
@@ -25,7 +25,7 @@ import (
 	pi "github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
 	pt "github.com/CovenantSQL/CovenantSQL/blockproducer/types"
 	"github.com/CovenantSQL/CovenantSQL/proto"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/cmd/cql-adapter/config/config.go
+++ b/cmd/cql-adapter/config/config.go
@@ -29,7 +29,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/cmd/cql-adapter/storage"
 	"github.com/CovenantSQL/CovenantSQL/conf"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (

--- a/cmd/cql-adapter/storage/sqlite3.go
+++ b/cmd/cql-adapter/storage/sqlite3.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+
 	// Import sqlite3 manually.
 	_ "github.com/CovenantSQL/go-sqlite3-encrypt"
 )

--- a/cmd/cql-faucet/config.go
+++ b/cmd/cql-faucet/config.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Config defines the configurable options for faucet application backend.

--- a/cmd/cql-faucet/persistence.go
+++ b/cmd/cql-faucet/persistence.go
@@ -25,7 +25,8 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/client"
 	"github.com/CovenantSQL/CovenantSQL/conf"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
+
 	// Load sqlite3 database driver.
 	_ "github.com/CovenantSQL/go-sqlite3-encrypt"
 )

--- a/cmd/cql-minerd/integration_test.go
+++ b/cmd/cql-minerd/integration_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/rpc"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/CovenantSQL/go-sqlite3-encrypt"
+	sqlite3 "github.com/CovenantSQL/go-sqlite3-encrypt"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/cmd/cql-minerd/main.go
+++ b/cmd/cql-minerd/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+
 	//"runtime/trace"
 	"syscall"
 	"time"
@@ -39,8 +40,8 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"github.com/CovenantSQL/CovenantSQL/worker"
-	"github.com/cyberdelia/go-metrics-graphite"
-	"github.com/rcrowley/go-metrics"
+	graphite "github.com/cyberdelia/go-metrics-graphite"
+	metrics "github.com/rcrowley/go-metrics"
 )
 
 const logo = `

--- a/cmd/cql-observer/config.go
+++ b/cmd/cql-observer/config.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Database defines single database subscription status.

--- a/cmd/cql-observer/service.go
+++ b/cmd/cql-observer/service.go
@@ -35,7 +35,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/types"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 const (

--- a/cmd/cql-utils/adapterconfgen.go
+++ b/cmd/cql-utils/adapterconfgen.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type adapterConfig struct {

--- a/cmd/cql-utils/rpc.go
+++ b/cmd/cql-utils/rpc.go
@@ -35,7 +35,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/sqlchain"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"github.com/CovenantSQL/CovenantSQL/worker"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (

--- a/cmd/cql/main.go
+++ b/cmd/cql/main.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CovenantSQL/go-sqlite3-encrypt"
+	sqlite3 "github.com/CovenantSQL/go-sqlite3-encrypt"
 	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/env"

--- a/cmd/cql/util.go
+++ b/cmd/cql/util.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/CovenantSQL/go-sqlite3-encrypt"
+	sqlite3 "github.com/CovenantSQL/go-sqlite3-encrypt"
 )
 
 // SqTime provides a type that will correctly scan the various timestamps

--- a/cmd/hotfix/observer-upgrade/main.go
+++ b/cmd/hotfix/observer-upgrade/main.go
@@ -26,7 +26,7 @@ import (
 	ct "github.com/CovenantSQL/CovenantSQL/sqlchain/otypes"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 type blockNode struct {

--- a/conf/config.go
+++ b/conf/config.go
@@ -26,7 +26,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/pow/cpuminer"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // these const specify the role of this app, which can be "miner", "blockProducer"

--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const testFile = "./.configtest"

--- a/crypto/asymmetric/keypair_test.go
+++ b/crypto/asymmetric/keypair_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	ec "github.com/btcsuite/btcd/btcec"
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestGenSecp256k1Keypair(t *testing.T) {

--- a/crypto/hash/hash_test.go
+++ b/crypto/hash/hash_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // mainNetGenesisHash is the hash of the first block in the block chain for the

--- a/crypto/hash/hashfuncs.go
+++ b/crypto/hash/hashfuncs.go
@@ -19,13 +19,14 @@ package hash
 import (
 	"encoding/binary"
 	"hash/fnv"
+
 	// "crypto/sha256" benchmark is at least 10% faster on
 	// i7-4870HQ CPU @ 2.50GHz than "github.com/minio/sha256-simd"
 	"crypto/sha256"
 	// "minio/blake2b-simd" benchmark is at least 3% faster on
 	// i7-4870HQ CPU @ 2.50GHz than "golang.org/x/crypto/blake2b"
 	// and supports more CPU instructions
-	"github.com/minio/blake2b-simd"
+	blake2b "github.com/minio/blake2b-simd"
 )
 
 // HashBSize is the size of HashB

--- a/crypto/kms/pubkeystore.go
+++ b/crypto/kms/pubkeystore.go
@@ -31,7 +31,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 // PublicKeyStore holds db and bucket name

--- a/crypto/kms/pubkeystore_test.go
+++ b/crypto/kms/pubkeystore_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const dbFile = ".test.db"

--- a/kayak/runtime_test.go
+++ b/kayak/runtime_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/storage"
 	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/jordwest/mock-conn"
+	mock_conn "github.com/jordwest/mock-conn"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/proto/nodeinfo_test.go
+++ b/proto/nodeinfo_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/crypto/hash"
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestNode_InitNodeCryptoInfo(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/twopc"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
+
 	// Register CovenantSQL/go-sqlite3-encrypt engine.
 	_ "github.com/CovenantSQL/go-sqlite3-encrypt"
 )

--- a/xenomint/sqlite/sqlite.go
+++ b/xenomint/sqlite/sqlite.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/storage"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
-	"github.com/CovenantSQL/go-sqlite3-encrypt"
+	sqlite3 "github.com/CovenantSQL/go-sqlite3-encrypt"
 )
 
 const (


### PR DESCRIPTION
New version `goimports` always try to give an alias for packages which pkg name does not match project name.