### PR TITLE
Fix some issues in block producer

### DIFF
--- a/blockproducer/chain.go
+++ b/blockproducer/chain.go
@@ -993,8 +993,8 @@ func (c *Chain) goFuncWithTimeout(f func(ctx context.Context), timeout time.Dura
 	go func() {
 		var ctx, ccl = context.WithTimeout(c.ctx, timeout)
 		defer func() {
-			ccl()
 			c.wg.Done()
+			ccl()
 		}()
 		f(ctx)
 	}()

--- a/blockproducer/chain.go
+++ b/blockproducer/chain.go
@@ -489,7 +489,7 @@ func (c *Chain) processTx(tx pi.Transaction) {
 	}(); ok {
 		log.WithFields(log.Fields{
 			"tx_hash": tx.Hash().Short(4),
-		}).Debugf("tx already exists, abort processing")
+		}).Debug("tx already exists, abort processing")
 		return
 	}
 	for _, s := range c.getPeers().Servers {
@@ -766,7 +766,7 @@ func (c *Chain) replaceAndSwitchToBranch(
 						}
 						return fmt.Sprintf("[%04d]", i)
 					}(),
-				}).Debugf("pruning branch")
+				}).Debug("pruning branch")
 			}
 		}
 		// Replace current branches

--- a/blockproducer/chain_test.go
+++ b/blockproducer/chain_test.go
@@ -189,7 +189,7 @@ func TestChain(t *testing.T) {
 				err = chain.storeTx(t1)
 				So(err, ShouldEqual, ErrExistedTx)
 			})
-			err = chain.produceBlock(begin.Add(chain.period))
+			err = chain.produceBlock(chain.ctx, begin.Add(chain.period))
 			So(err, ShouldBeNil)
 
 			// Create a sibling block from fork#0 and apply
@@ -204,14 +204,14 @@ func TestChain(t *testing.T) {
 
 			err = chain.storeTx(t2)
 			So(err, ShouldBeNil)
-			err = chain.produceBlock(begin.Add(2 * chain.period))
+			err = chain.produceBlock(chain.ctx, begin.Add(2*chain.period))
 			So(err, ShouldBeNil)
 
 			err = chain.storeTx(t3)
 			So(err, ShouldBeNil)
 			err = chain.storeTx(t4)
 			So(err, ShouldBeNil)
-			err = chain.produceBlock(begin.Add(3 * chain.period))
+			err = chain.produceBlock(chain.ctx, begin.Add(3*chain.period))
 			So(err, ShouldBeNil)
 			// Create a sibling block from fork#1 and apply
 			f1, bl, err = f1.produceBlock(3, begin.Add(3*chain.period), addr2, priv2)
@@ -222,7 +222,7 @@ func TestChain(t *testing.T) {
 
 			// This should trigger a branch pruning on fork #0
 			for i := uint32(4); i <= 6; i++ {
-				err = chain.produceBlock(begin.Add(time.Duration(i) * chain.period))
+				err = chain.produceBlock(chain.ctx, begin.Add(time.Duration(i)*chain.period))
 				So(err, ShouldBeNil)
 				// Create a sibling block from fork#1 and apply
 				f1, bl, err = f1.produceBlock(
@@ -236,7 +236,7 @@ func TestChain(t *testing.T) {
 			Convey("The chain immutable should be updated to irreversible block", func() {
 				// Add more blocks to trigger immutable updating
 				for i := uint32(7); i <= 12; i++ {
-					err = chain.produceBlock(begin.Add(time.Duration(i) * chain.period))
+					err = chain.produceBlock(chain.ctx, begin.Add(time.Duration(i)*chain.period))
 					So(err, ShouldBeNil)
 				}
 				Convey("The chain should have same state after reloading", func() {

--- a/blockproducer/chain_test.go
+++ b/blockproducer/chain_test.go
@@ -189,7 +189,7 @@ func TestChain(t *testing.T) {
 				err = chain.storeTx(t1)
 				So(err, ShouldEqual, ErrExistedTx)
 			})
-			err = chain.produceBlock(chain.ctx, begin.Add(chain.period))
+			err = chain.produceBlock(begin.Add(chain.period))
 			So(err, ShouldBeNil)
 
 			// Create a sibling block from fork#0 and apply
@@ -204,14 +204,14 @@ func TestChain(t *testing.T) {
 
 			err = chain.storeTx(t2)
 			So(err, ShouldBeNil)
-			err = chain.produceBlock(chain.ctx, begin.Add(2*chain.period))
+			err = chain.produceBlock(begin.Add(2 * chain.period))
 			So(err, ShouldBeNil)
 
 			err = chain.storeTx(t3)
 			So(err, ShouldBeNil)
 			err = chain.storeTx(t4)
 			So(err, ShouldBeNil)
-			err = chain.produceBlock(chain.ctx, begin.Add(3*chain.period))
+			err = chain.produceBlock(begin.Add(3 * chain.period))
 			So(err, ShouldBeNil)
 			// Create a sibling block from fork#1 and apply
 			f1, bl, err = f1.produceBlock(3, begin.Add(3*chain.period), addr2, priv2)
@@ -222,7 +222,7 @@ func TestChain(t *testing.T) {
 
 			// This should trigger a branch pruning on fork #0
 			for i := uint32(4); i <= 6; i++ {
-				err = chain.produceBlock(chain.ctx, begin.Add(time.Duration(i)*chain.period))
+				err = chain.produceBlock(begin.Add(time.Duration(i) * chain.period))
 				So(err, ShouldBeNil)
 				// Create a sibling block from fork#1 and apply
 				f1, bl, err = f1.produceBlock(
@@ -236,7 +236,7 @@ func TestChain(t *testing.T) {
 			Convey("The chain immutable should be updated to irreversible block", func() {
 				// Add more blocks to trigger immutable updating
 				for i := uint32(7); i <= 12; i++ {
-					err = chain.produceBlock(chain.ctx, begin.Add(time.Duration(i)*chain.period))
+					err = chain.produceBlock(begin.Add(time.Duration(i) * chain.period))
 					So(err, ShouldBeNil)
 				}
 				Convey("The chain should have same state after reloading", func() {

--- a/crypto/verifier/common.go
+++ b/crypto/verifier/common.go
@@ -75,7 +75,7 @@ func (i *DefaultHashSignVerifierImpl) Verify(mh MarshalHasher) (err error) {
 		err = errors.WithStack(ErrHashValueNotMatch)
 		return
 	}
-	if !i.Signature.Verify(h[:], i.Signee) {
+	if i.Signature == nil || i.Signee == nil || !i.Signature.Verify(h[:], i.Signee) {
 		err = errors.WithStack(ErrSignatureNotMatch)
 		return
 	}

--- a/crypto/verifier/common_test.go
+++ b/crypto/verifier/common_test.go
@@ -79,6 +79,20 @@ func TestDefaultHashSignVerifierImpl(t *testing.T) {
 					So(err, ShouldEqual, ErrHashValueNotMatch)
 				})
 			})
+			Convey("When the signee is not set", func() {
+				obj.HSV.Signee = nil
+				Convey("The verifier should return signature not match error", func() {
+					err = errors.Cause(obj.Verify())
+					So(err, ShouldEqual, ErrSignatureNotMatch)
+				})
+			})
+			Convey("When the signature is not set", func() {
+				obj.HSV.Signature = nil
+				Convey("The verifier should return signature not match error", func() {
+					err = errors.Cause(obj.Verify())
+					So(err, ShouldEqual, ErrSignatureNotMatch)
+				})
+			})
 			Convey("When the signee is modified", func() {
 				var _, pub, err = asymmetric.GenSecp256k1KeyPair()
 				So(err, ShouldBeNil)


### PR DESCRIPTION
### Tx flooding
The AddTx broadcasting needs a TTL control, or simply check local existence first.

### DATARACE
Calling WaitGroup.Add in RPC handling goroutine main cause DATARACE: calls with a positive delta that occur when the counter is zero must happen before a Wait.
Use new WaitGroup instance while creating new sub-goroutines in a worker goroutine instead.
This also changes the broadcasting mode from nonblocking to blocking the worker goroutine -- but will be fine with the timeout context, if they work properly.

### Nil field
Also check nil signee or signature in default verifier implementation.
