### PR TITLE
Fix issue: duplicate branches

### DIFF
--- a/blockproducer/chain.go
+++ b/blockproducer/chain.go
@@ -782,6 +782,9 @@ func (c *Chain) applyBlock(bl *types.BPBlock) (err error) {
 			// Return silently if block exists in the current branch
 			return
 		}
+	}
+
+	for _, v := range c.branches {
 		// Fork and create new branch
 		if parent, ok = v.head.hasAncestorWithMinCount(
 			bl.SignedHeader.ParentHash, c.lastIrre.count,

--- a/blockproducer/chain_test.go
+++ b/blockproducer/chain_test.go
@@ -17,6 +17,7 @@
 package blockproducer
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -232,6 +233,13 @@ func TestChain(t *testing.T) {
 				f1.preview.commit()
 				err = chain.pushBlock(bl)
 				So(err, ShouldBeNil)
+
+				Convey(fmt.Sprintf("Bug regression: duplicate branch #%d", i), func() {
+					var branchCount = len(chain.branches)
+					err = chain.pushBlock(bl)
+					So(err, ShouldBeNil)
+					So(branchCount, ShouldEqual, len(chain.branches))
+				})
 			}
 
 			Convey("The chain immutable should be updated to irreversible block", func() {


### PR DESCRIPTION
A duplicate block check should be done before any further check, or it may produce a duplicate branch.