### PR TITLE
Fix when rCount != ETLSHeaderSize, err == nil

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -179,10 +179,16 @@ func handleCipher(conn net.Conn) (cryptoConn *etls.CryptoConn, err error) {
 	// NodeID + Uint256 Nonce
 	headerBuf := make([]byte, ETLSHeaderSize)
 	rCount, err := conn.Read(headerBuf)
-	if err != nil || rCount != ETLSHeaderSize {
+	if err != nil {
 		log.WithError(err).Error("read node header error")
 		return
 	}
+
+	if rCount != ETLSHeaderSize {
+		err = errors.New("invalid ETLS header size")
+		return
+	}
+
 	if headerBuf[0] != etls.ETLSMagicBytes[0] || headerBuf[1] != etls.ETLSMagicBytes[1] {
 		err = errors.New("bad ETLS header")
 		return


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x96f6c2]

goroutine 488650 [running]:
github.com/CovenantSQL/CovenantSQL/crypto/etls.(*CryptoConn).Close(0x0, 0x0, 0x0)
	/go/src/github.com/CovenantSQL/CovenantSQL/crypto/etls/conn.go:132 +0x22
panic(0xe18660, 0x19b02b0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/CovenantSQL/CovenantSQL/rpc.(*Server).handleConn(0xc00021f6b0, 0x115d1e0, 0x0)
	/go/src/github.com/CovenantSQL/CovenantSQL/rpc/server.go:128 +0x89
created by github.com/CovenantSQL/CovenantSQL/rpc.(*Server).Serve
	/go/src/github.com/CovenantSQL/CovenantSQL/rpc/server.go:114 +0x9b