### PR TITLE
Fix block producers forking on startup

### DIFF
--- a/blockproducer/branch.go
+++ b/blockproducer/branch.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	pi "github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
-	pl "github.com/CovenantSQL/CovenantSQL/blockproducer/limits"
+	"github.com/CovenantSQL/CovenantSQL/conf"
 	ca "github.com/CovenantSQL/CovenantSQL/crypto/asymmetric"
 	"github.com/CovenantSQL/CovenantSQL/crypto/hash"
 	"github.com/CovenantSQL/CovenantSQL/proto"
@@ -57,7 +57,7 @@ func newBranch(
 	}
 	// Apply new blocks to view and pool
 	for _, bn := range list {
-		if len(bn.block.Transactions) > pl.MaxTransactionsPerBlock {
+		if len(bn.block.Transactions) > conf.MaxTransactionsPerBlock {
 			return nil, ErrTooManyTransactionsInBlock
 		}
 
@@ -132,7 +132,7 @@ func (b *branch) applyBlock(n *blockNode) (br *branch, err error) {
 	}
 	var cpy = b.makeArena()
 
-	if len(n.block.Transactions) > pl.MaxTransactionsPerBlock {
+	if len(n.block.Transactions) > conf.MaxTransactionsPerBlock {
 		return nil, ErrTooManyTransactionsInBlock
 	}
 
@@ -185,7 +185,7 @@ func (b *branch) produceBlock(
 		cpy       = b.makeArena()
 		txs       = cpy.sortUnpackedTxs()
 		ierr      error
-		packCount = pl.MaxTransactionsPerBlock
+		packCount = conf.MaxTransactionsPerBlock
 	)
 
 	if len(txs) < packCount {

--- a/blockproducer/chain.go
+++ b/blockproducer/chain.go
@@ -557,11 +557,11 @@ func (c *Chain) blockingSyncCurrentHead(ctx context.Context, requiredReachable u
 	ticker = time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
+		if c.syncCurrentHead(ctx, requiredReachable) {
+			return
+		}
 		select {
 		case <-ticker.C:
-			if c.syncCurrentHead(ctx, requiredReachable) {
-				return
-			}
 		case <-ctx.Done():
 			err = ctx.Err()
 			return

--- a/blockproducer/config.go
+++ b/blockproducer/config.go
@@ -24,10 +24,6 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/types"
 )
 
-const (
-	blockVersion int32 = 0x01
-)
-
 // Config is the main chain configuration.
 type Config struct {
 	Mode    string

--- a/conf/limits.go
+++ b/conf/limits.go
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-// Package limits defines limits of the CovenantSQL system.
-package limits
+package conf
 
 const (
 	// MaxTxBroadcastTTL defines the TTL limit of a AddTx request broadcasting within the

--- a/conf/parameters.go
+++ b/conf/parameters.go
@@ -18,6 +18,7 @@ package conf
 
 import "time"
 
+// This parameters should be kept consistent in all BPs.
 const (
 	// BPPeriod is the block producer block produce period.
 	BPPeriod = 3 * time.Second
@@ -29,4 +30,11 @@ const (
 	SQLChainTick = 1 * time.Second
 	// SQLChainTTL is the sqlchain unack query billing ttl.
 	SQLChainTTL = 10
+
+	DefaultConfirmThreshold = float64(2) / 3.0
+)
+
+// This parameters will not cause inconsistency within certain range.
+const (
+	BPStartupRequiredReachableCount = 2 // NOTE: this includes myself
 )

--- a/conf/parameters.go
+++ b/conf/parameters.go
@@ -16,8 +16,6 @@
 
 package conf
 
-import "time"
-
 // This parameters should be kept consistent in all BPs.
 const (
 	DefaultConfirmThreshold = float64(2) / 3.0

--- a/conf/parameters.go
+++ b/conf/parameters.go
@@ -20,17 +20,6 @@ import "time"
 
 // This parameters should be kept consistent in all BPs.
 const (
-	// BPPeriod is the block producer block produce period.
-	BPPeriod = 3 * time.Second
-	// BPTick is the block produce block fetch tick.
-	BPTick = 1 * time.Second
-	// SQLChainPeriod is the sqlchain block produce period.
-	SQLChainPeriod = 3 * time.Second
-	// SQLChainTick is the sqlchain block fetch tick.
-	SQLChainTick = 1 * time.Second
-	// SQLChainTTL is the sqlchain unack query billing ttl.
-	SQLChainTTL = 10
-
 	DefaultConfirmThreshold = float64(2) / 3.0
 )
 


### PR DESCRIPTION
# Fixes
1. Move limits package to conf.
2. Fix a height overflow issue while calculating with time before genesis time.
3. Add a parameter to configure required reachable BPs for genesis startup.

# Notes
Configuring a `conf.BPStartupRequiredReachableCount` which is greater than 1 will require the genesis time to be in the future for a genesis startup, otherwise, no BP will be able to move forward.
And it also requires at least `conf.BPStartupRequiredReachableCount`-1 BP(s) to be alive at any time, or the BP network will stop working forever.