### PR TITLE
Use 114 DNS for default

### DIFF
--- a/bin/docker-entry.sh
+++ b/bin/docker-entry.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#echo nameserver 1.1.1.1 > /etc/resolv.conf
+echo nameserver 114.114.114.114 > /etc/resolv.conf
 
 [ -s "${COVENANT_ALERT}" ] && [ -x "${COVENANT_ALERT}" ] && (eval "${COVENANT_ALERT}")
 


### PR DESCRIPTION
Use 114 DNS for default, docker default DNS will make runtime crash in net._C2func_getaddrinfo. Dig it later

make docker warning:
```
# github.com/CovenantSQL/CovenantSQL/cmd/cqld.test
/tmp/go-link-692753728/000023.o: In function `_cgo_18049202ccd9_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:49: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

```
goroutine 62 [syscall]:
runtime.cgocall(0xb82bd0, 0xc00023d600, 0x29)
  /usr/local/go/src/runtime/cgocall.go:128 +0x5e fp=0xc00023d5c8 sp=0xc00023d590 pc=0x40625e
net._C2func_getaddrinfo(0xc02021f740, 0x0, 0xc011c03350, 0xc0004d0a78, 0x0, 0x0, 0x0)
  _cgo_gotypes.go:91 +0x55 fp=0xc00023d600 sp=0xc00023d5c8 pc=0x56ab05
net.cgoLookupIPCNAME.func1(0xc02021f740, 0x0, 0xc011c03350, 0xc0004d0a78, 0x11, 0x11, 0x1238dbb0274e266)
  /usr/local/go/src/net/cgo_unix.go:149 +0x131 fp=0xc00023d648 sp=0xc00023d600 pc=0x570231
net.cgoLookupIPCNAME(0xc000694740, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
  /usr/local/go/src/net/cgo_unix.go:149 +0x153 fp=0xc00023d738 sp=0xc00023d648 pc=0x56c0c3
net.cgoIPLookup(0xc0202134a0, 0xc000694740, 0x10)
  /usr/local/go/src/net/cgo_unix.go:201 +0x4d fp=0xc00023d7c8 sp=0xc00023d738 pc=0x56c77d
runtime.goexit()
  /usr/local/go/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc00023d7d0 sp=0xc00023d7c8 pc=0x45d5e1
created by net.cgoLookupIP
  /usr/local/go/src/net/cgo_unix.go:211 +0xad
  
```