### PR TITLE
Use ~/.cql/ directory as default config location.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ before_script:
 test-my-project:
   stage: test
   script: 
-    - set -x
     - ./alltest.sh
 
 compatibility-testnet:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,9 @@ test-my-project:
 compatibility-testnet:
   stage: test
   script:
+    - set -o errexit
+    - set -o pipefail
     - make clean
     - make -j8 client
     - go test -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
-    - bash test/testnet_client/run.sh
+    - bash -x test/testnet_client/run.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,9 @@ compatibility-testnet:
   script:
     - set -o errexit
     - set -o pipefail
+    - commit=$(git rev-parse --short HEAD)
+    - branch=$(git branch -rv |grep $commit | awk '{print $1}')
+    - if [[ $branch =~ "/beta_" ]]; then exit 0; fi
     - make clean
     - make -j8 client
     - go test -tags "$UNITTESTTAGS" -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ variables:
   REVIEWDOG_VERSION: 0.9.11
   REVIEWDOG_GITLAB_API_TOKEN: $REVIEWDOG_TOKEN
   CODECOV_TOKEN: $CODECOV_TOKEN
-  UNITTESTTAGS: -tags "linux sqlite_omit_load_extension"
+  UNITTESTTAGS: linux sqlite_omit_load_extension
 
 before_script:
   # Setup dependency management tool
@@ -37,5 +37,5 @@ compatibility-testnet:
     - set -o pipefail
     - make clean
     - make -j8 client
-    - go test $UNITTESTTAGS -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
+    - go test -tags "$UNITTESTTAGS" -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
     - bash -x test/testnet_client/run.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,11 +25,14 @@ before_script:
 
 test-my-project:
   stage: test
-  script: ./alltest.sh
+  script: 
+    - set -x
+    - ./alltest.sh
 
 compatibility-testnet:
   stage: test
   script:
+    - set -x
     - set -o errexit
     - set -o pipefail
     - make clean

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ variables:
   REVIEWDOG_VERSION: 0.9.11
   REVIEWDOG_GITLAB_API_TOKEN: $REVIEWDOG_TOKEN
   CODECOV_TOKEN: $CODECOV_TOKEN
+  UNITTESTTAGS: -tags "linux sqlite_omit_load_extension"
 
 before_script:
   # Setup dependency management tool
@@ -33,5 +34,5 @@ compatibility-testnet:
     - set -o pipefail
     - make clean
     - make -j8 client
-    - go test -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
+    - go test $UNITTESTTAGS -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
     - bash -x test/testnet_client/run.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,10 +32,10 @@ test-my-project:
 compatibility-testnet:
   stage: test
   script:
-    - set -x
     - set -o errexit
     - set -o pipefail
     - make clean
     - make -j8 client
     - go test -tags "$UNITTESTTAGS" -bench=^BenchmarkTestnetMiner2$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
-    - bash -x test/testnet_client/run.sh
+    - set -x
+    - ./test/testnet_client/run.sh

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ endif
 
 version := $(branch)-$(GIT_COMMIT)-$(builddate)
 
-tags := $(platform) sqlite_omit_load_extension osusergo
+tags := $(platform) sqlite_omit_load_extension
 testtags := $(tags) testbinary
 test_flags := -coverpkg github.com/CovenantSQL/CovenantSQL/... -cover -race -c
 

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ endif
 
 version := $(branch)-$(GIT_COMMIT)-$(builddate)
 
-tags := $(platform) sqlite_omit_load_extension
-testtags := $(platform) sqlite_omit_load_extension testbinary
+tags := $(platform) sqlite_omit_load_extension osusergo
+testtags := $(tags) testbinary
 test_flags := -coverpkg github.com/CovenantSQL/CovenantSQL/... -cover -race -c
 
 ldflags_role_bp := -X main.version=$(version) -X github.com/CovenantSQL/CovenantSQL/conf.RoleTag=B $$GOLDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ builddate := $(shell date +%Y%m%d%H%M%S)
 
 unamestr := $(shell uname)
 
-ifeq ($(unamestr),"Linux")
-platform := "linux"
+ifeq ($(unamestr),Linux)
+platform := linux
 endif
 
 version := $(branch)-$(GIT_COMMIT)-$(builddate)

--- a/alltest.sh
+++ b/alltest.sh
@@ -3,7 +3,6 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
 
 test::package() {
   local package="${1:-notset}"
@@ -27,6 +26,7 @@ main() {
     test::package "${package}"
   done
 
+  set -x
   gocovmerge *.cover.out $(find cmd -name "*.cover.out") | grep -F -v '_gen.go' > coverage.txt && rm -f *.cover.out
   bash <(curl -s https://codecov.io/bash)
 

--- a/alltest.sh
+++ b/alltest.sh
@@ -14,7 +14,7 @@ test::package() {
 
   local coverage_file="${package//\//.}.cover.out"
   echo "[TEST] package=${package}, coverage=${coverage_file}"
-  go test $UNITTESTTAGS -race -failfast -parallel 16 -cpu 16 -coverpkg="github.com/CovenantSQL/CovenantSQL/..." -coverprofile "${coverage_file}" "${package}"
+  go test -tags "$UNITTESTTAGS" -race -failfast -parallel 16 -cpu 16 -coverpkg="github.com/CovenantSQL/CovenantSQL/..." -coverprofile "${coverage_file}" "${package}"
 }
 
 main() {
@@ -30,9 +30,9 @@ main() {
   bash <(curl -s https://codecov.io/bash)
 
   # some benchmarks
-  go test $UNITTESTTAGS -bench=^BenchmarkPersistentCaller_Call$ -run ^$ ./rpc/
+  go test -tags "$UNITTESTTAGS" -bench=^BenchmarkPersistentCaller_Call$ -run ^$ ./rpc/
   bash cleanupDB.sh || true
-  go test $UNITTESTTAGS -bench=^BenchmarkMinerTwo$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
+  go test -tags "$UNITTESTTAGS" -bench=^BenchmarkMinerTwo$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
   bash cleanupDB.sh || true
 }
 

--- a/alltest.sh
+++ b/alltest.sh
@@ -3,6 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+set -x
 
 test::package() {
   local package="${1:-notset}"

--- a/alltest.sh
+++ b/alltest.sh
@@ -14,7 +14,7 @@ test::package() {
 
   local coverage_file="${package//\//.}.cover.out"
   echo "[TEST] package=${package}, coverage=${coverage_file}"
-  go test -race -failfast -parallel 16 -cpu 16 -coverpkg="github.com/CovenantSQL/CovenantSQL/..." -coverprofile "${coverage_file}" "${package}"
+  go test $UNITTESTTAGS -race -failfast -parallel 16 -cpu 16 -coverpkg="github.com/CovenantSQL/CovenantSQL/..." -coverprofile "${coverage_file}" "${package}"
 }
 
 main() {
@@ -30,9 +30,9 @@ main() {
   bash <(curl -s https://codecov.io/bash)
 
   # some benchmarks
-  go test -bench=^BenchmarkPersistentCaller_Call$ -run ^$ ./rpc/
+  go test $UNITTESTTAGS -bench=^BenchmarkPersistentCaller_Call$ -run ^$ ./rpc/
   bash cleanupDB.sh || true
-  go test -bench=^BenchmarkMinerTwo$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
+  go test $UNITTESTTAGS -bench=^BenchmarkMinerTwo$ -benchtime=5s -run ^$ ./cmd/cql-minerd/
   bash cleanupDB.sh || true
 }
 

--- a/client/_example/gdpaverage/gdpaverage.go
+++ b/client/_example/gdpaverage/gdpaverage.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 
 	"github.com/CovenantSQL/CovenantSQL/client"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
@@ -28,10 +29,12 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 	var config, password, dsn string
 
-	flag.StringVar(&config, "config", "./conf/config.yaml", "config file path")
+	flag.StringVar(&config, "config", "~/.cql/config.yaml", "config file path")
 	flag.StringVar(&dsn, "dsn", "", "database url")
 	flag.StringVar(&password, "password", "", "master key password for covenantsql")
 	flag.Parse()
+
+	config = utils.HomeDirExpand(config)
 
 	err := client.Init(config, []byte(password))
 	if err != nil {

--- a/client/_example/simple.go
+++ b/client/_example/simple.go
@@ -21,33 +21,27 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/CovenantSQL/CovenantSQL/client"
+	_ "github.com/CovenantSQL/CovenantSQL/client"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
 func main() {
 	log.SetLevel(log.InfoLevel)
-	var config, password, dsn string
+	var dsn string
 
-	flag.StringVar(&config, "config", "./conf/config.yaml", "config file path")
-	flag.StringVar(&dsn, "dsn", "", "database url")
-	flag.StringVar(&password, "password", "", "master key password for covenantsql")
+	flag.StringVar(&dsn, "dsn", "", "Database url")
 	flag.Parse()
 
-	err := client.Init(config, []byte(password))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if dsn == "" {
-		meta := client.ResourceMeta{}
-		meta.Node = 2
-		dsn, err = client.Create(meta)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer client.Drop(dsn)
-	}
+	// If your CovenantSQL config.yaml is not in ~/.cql/config.yaml
+	// Uncomment and edit following code
+	/*
+			config := "/data/myconfig/config.yaml"
+			password := "mypassword"
+		    err := client.Init(config, []byte(password))
+		    if err != nil {
+		        log.Fatal(err)
+		    }
+	*/
 
 	db, err := sql.Open("covenantsql", dsn)
 	if err != nil {

--- a/client/driver.go
+++ b/client/driver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/route"
 	"github.com/CovenantSQL/CovenantSQL/rpc"
 	"github.com/CovenantSQL/CovenantSQL/types"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"github.com/pkg/errors"
 )
@@ -63,12 +64,15 @@ var (
 	connIDAvail         []uint64
 	globalSeqNo         uint64
 	randSource          = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	defaultConfigFile = "~/.cql/config.yaml"
 )
 
 func init() {
 	d := new(covenantSQLDriver)
 	sql.Register(DBScheme, d)
 	sql.Register(DBSchemeAlias, d)
+	log.Debug("CovenantSQL driver registered.")
 }
 
 // covenantSQLDriver implements sql.Driver interface.
@@ -83,8 +87,10 @@ func (d *covenantSQLDriver) Open(dsn string) (conn driver.Conn, err error) {
 	}
 
 	if atomic.LoadUint32(&driverInitialized) == 0 {
-		err = ErrNotInitialized
-		return
+		err = defaultInit()
+		if err != nil && err != ErrAlreadyInitialized {
+			return
+		}
 	}
 
 	return newConn(cfg)
@@ -95,6 +101,18 @@ type ResourceMeta struct {
 	types.ResourceMeta
 	GasPrice       uint64
 	AdvancePayment uint64
+}
+
+func defaultInit() (err error) {
+	configFile := utils.HomeDirExpand(defaultConfigFile)
+	if configFile == defaultConfigFile {
+		//System not support ~ dir, need Init manually.
+		log.Debugf("Could not find CovenantSQL default config location: %v", configFile)
+		return ErrNotInitialized
+	}
+
+	log.Debugf("Using CovenantSQL default config location: %v", configFile)
+	return Init(configFile, []byte(""))
 }
 
 // Init defines init process for client.

--- a/client/driver.go
+++ b/client/driver.go
@@ -410,7 +410,6 @@ func WaitTxConfirmation(
 			return
 		}
 	}
-	return
 }
 
 func getNonce(addr proto.AccountAddress) (nonce interfaces.AccountNonce, err error) {

--- a/cmd/cql-adapter/README.md
+++ b/cmd/cql-adapter/README.md
@@ -42,12 +42,14 @@ Created a new certificate valid for the following names 📜
  - "server"
 
 The certificate is at "./server.pem" and the key at "./server-key.pem" ✅
+
+And move them to ~/.cql/ dir.
 ``````
 
 You can use following interactive command to generate adapter config.
 
 ```shell
-$ cql-utils -tool adapterconfgen -config config.yaml
+$ cql-utils -tool adapterconfgen
 ListenAddr (default: 0.0.0.0:4661): ⏎
 CertificatePath (default: server.pem): ⏎
 PrivateKeyPath (default: server-key.pem): ⏎
@@ -58,7 +60,7 @@ WriteCerts (default:): ⏎
 StorageDriver (default: covenantsql): ⏎
 StorageRoot (default:): ⏎
 
-$ tail -n 20 config.yaml
+$ tail -n 20 ~/.cql/config.yaml
 ... skipping irrelevant configuration
 Adapter:
   ListenAddr: 0.0.0.0:4661
@@ -79,7 +81,7 @@ Adapter:
 Start the adapter by following commands:
 
 ```shell
-$ cql-adapter -config config.yaml
+$ cql-adapter
 ```
 
 ### API

--- a/cmd/cql-adapter/main.go
+++ b/cmd/cql-adapter/main.go
@@ -41,8 +41,8 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "config file for adapter")
-	flag.StringVar(&password, "password", "", "master key password")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file for adapter")
+	flag.StringVar(&password, "password", "", "Master key password")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")

--- a/cmd/cql-adapter/main.go
+++ b/cmd/cql-adapter/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/CovenantSQL/CovenantSQL/crypto/asymmetric"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"golang.org/x/sys/unix"
 )
@@ -40,7 +41,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "./config.yaml", "config file for adapter")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "config file for adapter")
 	flag.StringVar(&password, "password", "", "master key password")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
@@ -54,6 +55,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-explorer/README.md
+++ b/cmd/cql-explorer/README.md
@@ -36,7 +36,7 @@ Usage of cql-explorer:
   -listen string
     	Listen address for http explorer api (default "127.0.0.1:4665")
   -password string
-        Master key password for covenantsql
+    	Master key password for covenantsql
 ```
 
 ### API

--- a/cmd/cql-explorer/README.md
+++ b/cmd/cql-explorer/README.md
@@ -21,7 +21,7 @@ Generate the main configuration file. Same as [Generating Default Config File in
 Start the explorer by following commands:
 
 ```shell
-$ cql-explorer -config config.yaml
+$ cql-explorer
 ```
 
 The available options are:
@@ -30,13 +30,13 @@ The available options are:
 $ cql-explorer --help
 Usage of cql-explorer:
   -config string
-    	config file path (default "./config.yaml")
+    	Config file path (default "~/.cql/config.yaml")
   -interval duration
-    	new block check interval for explorer (default 2s)
+    	New block check interval for explorer (default 2s)
   -listen string
-    	listen address for http explorer api (default "127.0.0.1:4665")
+    	Listen address for http explorer api (default "127.0.0.1:4665")
   -password string
-        master key password for covenantsql
+        Master key password for covenantsql
 ```
 
 ### API

--- a/cmd/cql-explorer/main.go
+++ b/cmd/cql-explorer/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/CovenantSQL/CovenantSQL/client"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
@@ -47,10 +48,10 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "./config.yaml", "config file path")
-	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4665", "listen address for http explorer api")
-	flag.DurationVar(&checkInterval, "interval", time.Second*2, "new block check interval for explorer")
-	flag.StringVar(&password, "password", "", "master key password for covenantsql")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file path")
+	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4665", "Listen address for http explorer api")
+	flag.DurationVar(&checkInterval, "interval", time.Second*2, "New block check interval for explorer")
+	flag.StringVar(&password, "password", "", "Master key password for covenantsql")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 }
 
@@ -64,6 +65,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-faucet/main.go
+++ b/cmd/cql-faucet/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/client"
 	"github.com/CovenantSQL/CovenantSQL/crypto/asymmetric"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"golang.org/x/sys/unix"
 )
@@ -42,8 +43,8 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "config.yaml", "configuration file for covenantsql")
-	flag.StringVar(&password, "password", "", "master key password for covenantsql")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Configuration file for covenantsql")
+	flag.StringVar(&password, "password", "", "Master key password for covenantsql")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
@@ -56,6 +57,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-fuse/main.go
+++ b/cmd/cql-fuse/main.go
@@ -76,6 +76,7 @@ import (
 	"bazil.org/fuse/fs"
 	_ "bazil.org/fuse/fs/fstestutil"
 	"github.com/CovenantSQL/CovenantSQL/client"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
@@ -87,23 +88,25 @@ var usage = func() {
 
 func main() {
 	var (
-		config     string
+		configFile string
 		dsn        string
 		mountPoint string
 		password   string
 		readOnly   bool
 	)
-	flag.StringVar(&config, "config", "./conf/config.yaml", "config file path")
-	flag.StringVar(&mountPoint, "mount", "./", "dir to mount")
-	flag.StringVar(&dsn, "dsn", "", "database url")
-	flag.StringVar(&password, "password", "", "master key password for covenantsql")
-	flag.BoolVar(&readOnly, "readonly", false, "mount read only volume")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file path")
+	flag.StringVar(&mountPoint, "mount", "./", "Dir to mount")
+	flag.StringVar(&dsn, "dsn", "", "Database url")
+	flag.StringVar(&password, "password", "", "Master key password for covenantsql")
+	flag.BoolVar(&readOnly, "readonly", false, "Mount read only volume")
 	flag.Usage = usage
 	flag.Parse()
 
 	log.SetLevel(log.InfoLevel)
 
-	err := client.Init(config, []byte(password))
+	configFile = utils.HomeDirExpand(configFile)
+
+	err := client.Init(configFile, []byte(password))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cql-minerd/main.go
+++ b/cmd/cql-minerd/main.go
@@ -96,7 +96,7 @@ func init() {
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
 
-	flag.StringVar(&configFile, "config", "./config.yaml", "Config file path")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file path")
 
 	flag.StringVar(&profileServer, "profile-server", "", "Profile server address, default not started")
 	flag.StringVar(&cpuProfile, "cpu-profile", "", "Path to file for CPU profiling information")
@@ -131,6 +131,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-mysql-adapter/README.md
+++ b/cmd/cql-mysql-adapter/README.md
@@ -22,7 +22,7 @@ Generate the main configuration file. Same as [Generating Default Config File in
 Start the mysql adapter by following commands:
 
 ```shell
-$ cql-mysql-adapter -config config.yaml
+$ cql-mysql-adapter
 ```
 
 The default mysql user is ```root``` and the default mysql password is ```calvin```, which can be modified as optional arguments of mysql adapter.
@@ -36,7 +36,7 @@ Usage of ./cql-mysql-adapter:
   -bypass-signature
     	Disable signature sign and verify, for testing
   -config string
-    	config file for mysql adapter (default "./config.yaml")
+    	config file for mysql adapter (default "~/.cql/config.yaml")
   -listen string
     	listen address for mysql adapter (default "127.0.0.1:4664")
   -mysql-password string

--- a/cmd/cql-mysql-adapter/main.go
+++ b/cmd/cql-mysql-adapter/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/client"
 	"github.com/CovenantSQL/CovenantSQL/crypto/asymmetric"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"golang.org/x/sys/unix"
 )
@@ -44,16 +45,16 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "./config.yaml", "config file for mysql adapter")
-	flag.StringVar(&password, "password", "", "master key password")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file for mysql adapter")
+	flag.StringVar(&password, "password", "", "Master key password")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 
-	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4664", "listen address for mysql adapter")
-	flag.StringVar(&mysqlUser, "mysql-user", "root", "mysql user for adapter server")
-	flag.StringVar(&mysqlPassword, "mysql-password", "calvin", "mysql password for adapter server")
-	flag.StringVar(&logLevel, "log-level", "", "service log level")
+	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4664", "Listen address for mysql adapter")
+	flag.StringVar(&mysqlUser, "mysql-user", "root", "MySQL user for adapter server")
+	flag.StringVar(&mysqlPassword, "mysql-password", "calvin", "MySQL password for adapter server")
+	flag.StringVar(&logLevel, "log-level", "", "Service log level")
 }
 
 func main() {
@@ -64,6 +65,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-observer/main.go
+++ b/cmd/cql-observer/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/crypto/kms"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/rpc"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
@@ -49,14 +50,14 @@ var (
 )
 
 func init() {
-	flag.StringVar(&configFile, "config", "./config.yaml", "config file path")
-	flag.StringVar(&dbID, "database", "", "database to listen for observation")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file path")
+	flag.StringVar(&dbID, "database", "", "Database to listen for observation")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
-	flag.StringVar(&resetPosition, "reset", "", "reset subscribe position")
-	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4663", "listen address for http explorer api")
-	flag.StringVar(&logLevel, "log-level", "", "service log level")
+	flag.StringVar(&resetPosition, "reset", "", "Reset subscribe position")
+	flag.StringVar(&listenAddr, "listen", "127.0.0.1:4663", "Listen address for http explorer api")
+	flag.StringVar(&logLevel, "log-level", "", "Service log level")
 }
 
 func main() {
@@ -69,6 +70,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/cmd/cql-utils/README-zh.md
+++ b/cmd/cql-utils/README-zh.md
@@ -11,19 +11,19 @@ $ go get github.com/CovenantSQL/CovenantSQL/cmd/cql-utils
 ### 生成公私钥对
 
 ```
-$ cql-utils -tool keygen
+$ cql-utils -tool confgen
 Enter master key(press Enter for default: ""): 
 ⏎
 Private key file: private.key
 Public key's hex: 03bc9e90e3301a2f5ae52bfa1f9e033cde81b6b6e7188b11831562bf5847bff4c0
 ```
 
-生成的 private.key 文件即是使用主密码加密过的私钥文件，而输出到屏幕上的字符串就是使用十六进制进行编码的公钥。
+生成的 ~/.cql/private.key 文件即是使用主密码加密过的私钥文件，而输出到屏幕上的字符串就是使用十六进制进行编码的公钥。
 
 ### 使用私钥文件或公钥生成钱包地址
 
 ```
-$ cql-utils -tool addrgen -private private.key
+$ cql-utils -tool addrgen
 Enter master key(default: ""):
 ⏎
 wallet address: 4jXvNvPHKNPU8Sncz5u5F5WSGcgXmzC1g8RuAXTCJzLsbF9Dsf9
@@ -31,4 +31,4 @@ $ cql-utils -tool addrgen -public 02f2707c1c6955a9019cd9d02ade37b931fbfa286a1163
 wallet address: 4jXvNvPHKNPU8Sncz5u5F5WSGcgXmzC1g8RuAXTCJzLsbF9Dsf9
 ```
 
-你可以通过指定私钥文件，或者把上述的公钥十六进制编码字符串作为命令行参数来直接生成钱包地址。
+你也可以通过-private指定私钥文件，或者把上述的公钥十六进制编码字符串作为命令行参数来直接生成钱包地址。

--- a/cmd/cql-utils/README.md
+++ b/cmd/cql-utils/README.md
@@ -11,19 +11,19 @@ $ go get github.com/CovenantSQL/CovenantSQL/cmd/cql-utils
 ### Generate Key Pair
 
 ```
-$ cql-utils -tool keygen
+$ cql-utils -tool confgen
 Enter master key(press Enter for default: ""): 
 ⏎
 Private key file: private.key
 Public key's hex: 03bc9e90e3301a2f5ae52bfa1f9e033cde81b6b6e7188b11831562bf5847bff4c0
 ```
 
-The private.key is your encrypted private key file, and the pubkey hex is your public key's hex.
+The ~/.cql/private.key is your encrypted private key file, and the pubkey hex is your public key's hex.
 
 ### Generate Wallet Address from existing Key
 
 ```
-$ cql-utils -tool addrgen -private private.key
+$ cql-utils -tool addrgen
 Enter master key(default: ""):
 ⏎
 wallet address: 4jXvNvPHKNPU8Sncz5u5F5WSGcgXmzC1g8RuAXTCJzLsbF9Dsf9
@@ -31,4 +31,4 @@ $ cql-utils -tool addrgen -public 02f2707c1c6955a9019cd9d02ade37b931fbfa286a1163
 wallet address: 4jXvNvPHKNPU8Sncz5u5F5WSGcgXmzC1g8RuAXTCJzLsbF9Dsf9
 ```
 
-You can generate your *wallet* address for test net according to your private key or public key.
+You can generate your *wallet* address for test net according to your private key(default ~/.cql/private) or public key.

--- a/cmd/cql-utils/confgen.go
+++ b/cmd/cql-utils/confgen.go
@@ -62,7 +62,11 @@ func runConfgen() {
 			os.Exit(1)
 		}
 		if strings.Compare(t, "y") == 0 || strings.Compare(t, "yes") == 0 {
-			os.RemoveAll(workingRoot)
+			err = os.RemoveAll(workingRoot)
+			if err != nil {
+				log.WithError(err).Error("unexpected error")
+				os.Exit(1)
+			}
 		} else {
 			os.Exit(0)
 		}

--- a/cmd/cql-utils/confgen.go
+++ b/cmd/cql-utils/confgen.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/CovenantSQL/CovenantSQL/conf/testnet"
 	"github.com/CovenantSQL/CovenantSQL/proto"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -36,10 +37,11 @@ var (
 )
 
 func init() {
-	flag.StringVar(&workingRoot, "root", "conf", "confgen root is the working root directory containing all auto-generating keys and certifications")
+	flag.StringVar(&workingRoot, "root", "~/.cql", "confgen root is the working root directory containing all auto-generating keys and certifications")
 }
 
 func runConfgen() {
+	workingRoot = utils.HomeDirExpand(workingRoot)
 	if workingRoot == "" {
 		log.Error("root directory is required for confgen")
 		os.Exit(1)

--- a/cmd/cql-utils/main.go
+++ b/cmd/cql-utils/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"syscall"
 
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -44,8 +45,8 @@ func init() {
 
 	flag.StringVar(&tool, "tool", "", "tool type, miner, keygen, keytool, rpc, nonce, confgen, addrgen, adapterconfgen")
 	flag.StringVar(&publicKeyHex, "public", "", "public key hex string to mine node id/nonce")
-	flag.StringVar(&privateKeyFile, "private", "private.key", "private key file to generate/show")
-	flag.StringVar(&configFile, "config", "config.yaml", "config file to use")
+	flag.StringVar(&privateKeyFile, "private", "~/.cql/private.key", "private key file to generate/show")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "config file to use")
 	flag.BoolVar(&skipMasterKey, "skip-master-key", false, "use empty master key")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 }
@@ -58,6 +59,9 @@ func main() {
 		os.Exit(0)
 	}
 	log.Infof("cql-utils build: %#v\n", version)
+
+	configFile = utils.HomeDirExpand(configFile)
+	privateKeyFile = utils.HomeDirExpand(privateKeyFile)
 
 	switch tool {
 	case "miner":

--- a/cmd/cql-utils/main.go
+++ b/cmd/cql-utils/main.go
@@ -43,11 +43,11 @@ const name = "cql-utils"
 func init() {
 	log.SetLevel(log.InfoLevel)
 
-	flag.StringVar(&tool, "tool", "", "tool type, miner, keytool, rpc, nonce, confgen, addrgen, adapterconfgen")
-	flag.StringVar(&publicKeyHex, "public", "", "public key hex string to mine node id/nonce")
-	flag.StringVar(&privateKeyFile, "private", "~/.cql/private.key", "private key file to generate/show")
-	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "config file to use")
-	flag.BoolVar(&skipMasterKey, "skip-master-key", false, "use empty master key")
+	flag.StringVar(&tool, "tool", "", "Tool type, miner, keytool, rpc, nonce, confgen, addrgen, adapterconfgen")
+	flag.StringVar(&publicKeyHex, "public", "", "Public key hex string to mine node id/nonce")
+	flag.StringVar(&privateKeyFile, "private", "~/.cql/private.key", "Private key file to generate/show")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file to use")
+	flag.BoolVar(&skipMasterKey, "skip-master-key", false, "Use empty master key")
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 }
 

--- a/cmd/cql-utils/main.go
+++ b/cmd/cql-utils/main.go
@@ -43,7 +43,7 @@ const name = "cql-utils"
 func init() {
 	log.SetLevel(log.InfoLevel)
 
-	flag.StringVar(&tool, "tool", "", "tool type, miner, keygen, keytool, rpc, nonce, confgen, addrgen, adapterconfgen")
+	flag.StringVar(&tool, "tool", "", "tool type, miner, keytool, rpc, nonce, confgen, addrgen, adapterconfgen")
 	flag.StringVar(&publicKeyHex, "public", "", "public key hex string to mine node id/nonce")
 	flag.StringVar(&privateKeyFile, "private", "~/.cql/private.key", "private key file to generate/show")
 	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "config file to use")
@@ -71,13 +71,14 @@ func main() {
 			os.Exit(1)
 		}
 		runMiner()
-	case "keygen":
-		if privateKeyFile == "" {
-			// error
-			log.Error("privateKey path is required for keygen")
-			os.Exit(1)
-		}
-		runKeygen()
+	// Disable keygen independent call
+	//case "keygen":
+	//	if privateKeyFile == "" {
+	//		// error
+	//		log.Error("privateKey path is required for keygen")
+	//		os.Exit(1)
+	//	}
+	//	runKeygen()
 	case "keytool":
 		if privateKeyFile == "" {
 			// error

--- a/cmd/cql/README-zh.md
+++ b/cmd/cql/README-zh.md
@@ -19,7 +19,7 @@ $ go get github.com/CovenantSQL/CovenantSQL/cmd/cql
 
 使用 `cql` 命令来检查钱包余额：
 ```bash
-$ cql -config conf/config.yaml -get-balance
+$ cql -get-balance
 INFO[0000] 
 ### Public Key ###
 0388954cf083bb6bb2b9c7248849b57c76326296fcc0d69764fc61eedb5b8d820c
@@ -36,7 +36,7 @@ INFO[0000] covenant coin balance is: 0                   caller="main.go:247 mai
 
 ```bash
 # if a non-default password applied on master key, use `-password` to pass it
-$ cql -config conf/config.yaml -create 1
+$ cql -create 1
 INFO[0000]
 ### Public Key ###
 039bc931161383c994ab9b81e95ddc1494b0efeb1cb735bb91e1043a1d6b98ebfd
@@ -48,7 +48,7 @@ INFO[0000] the newly created database is: covenantsql://0e9103318821b027f35b96c4
 这里 `-create 1` 表示创建一个单节点的 SQLChain。
 
 ```bash
-$ cql -config conf/config.yaml -dsn covenantsql://address
+$ cql -dsn covenantsql://address
 ```
 `address` 就是你的数据库 ID。
 

--- a/cmd/cql/README.md
+++ b/cmd/cql/README.md
@@ -19,7 +19,7 @@ See: [cql-utils doc](https://github.com/CovenantSQL/CovenantSQL/tree/develop/cmd
 
 Use `cql` to check your wallet balance:
 ```bash
-$ cql -config conf/config.yaml -get-balance
+$ cql -get-balance
 INFO[0000] 
 ### Public Key ###
 0388954cf083bb6bb2b9c7248849b57c76326296fcc0d69764fc61eedb5b8d820c
@@ -37,7 +37,7 @@ You can get a database id when create a new SQL Chain:
 
 ```bash
 # if a non-default password applied on master key, use `-password` to pass it
-$ cql -config conf/config.yaml -create 1
+$ cql -create 1
 INFO[0000]
 ### Public Key ###
 039bc931161383c994ab9b81e95ddc1494b0efeb1cb735bb91e1043a1d6b98ebfd
@@ -49,7 +49,7 @@ INFO[0000] the newly created database is: covenantsql://0e9103318821b027f35b96c4
 Here, `-create 1` refers that there is only one node in SQL Chain.
 
 ```bash
-$ cql -config conf/config.yaml -dsn covenantsql://address
+$ cql -dsn covenantsql://address
 ```
 `address` is database id. 
 

--- a/cmd/cql/main.go
+++ b/cmd/cql/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/crypto/hash"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/types"
+	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 	sqlite3 "github.com/CovenantSQL/go-sqlite3-encrypt"
 	"github.com/xo/dburl"
@@ -216,7 +217,7 @@ func init() {
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
 	flag.StringVar(&outFile, "out", "", "Record stdout to file")
-	flag.StringVar(&configFile, "config", "config.yaml", "Config file for covenantsql")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file for covenantsql")
 	flag.StringVar(&password, "password", "", "Master key password for covenantsql")
 	flag.BoolVar(&singleTransaction, "single-transaction", false, "Execute as a single transaction (if non-interactive)")
 	flag.Var(&variables, "variable", "Set variable")
@@ -238,6 +239,9 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+	log.Infof("cql build: %#v\n", version)
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	var err error
 

--- a/cmd/cqld/main.go
+++ b/cmd/cqld/main.go
@@ -71,7 +71,7 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "Show version information and exit")
 	flag.BoolVar(&asymmetric.BypassSignature, "bypass-signature", false,
 		"Disable signature sign and verify, for testing")
-	flag.StringVar(&configFile, "config", "./config.yaml", "Config file path")
+	flag.StringVar(&configFile, "config", "~/.cql/config.yaml", "Config file path")
 
 	flag.StringVar(&cpuProfile, "cpu-profile", "", "Path to file for CPU profiling information")
 	flag.StringVar(&memProfile, "mem-profile", "", "Path to file for memory profiling information")
@@ -105,6 +105,8 @@ func main() {
 			name, version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		os.Exit(0)
 	}
+
+	configFile = utils.HomeDirExpand(configFile)
 
 	flag.Visit(func(f *flag.Flag) {
 		log.Infof("args %#v : %s", f.Name, f.Value)

--- a/test/testnet_client/run.sh
+++ b/test/testnet_client/run.sh
@@ -13,7 +13,7 @@ echo ${PROJECT_DIR}
 
 cd ${TEST_WD}
 echo -ne "y\n" | ${PROJECT_DIR}/bin/cql-utils -tool confgen -skip-master-key
-${PROJECT_DIR}/bin/cql-utils -tool addrgen -private ./conf/private.key -skip-master-key | tee wallet.txt
+${PROJECT_DIR}/bin/cql-utils -tool addrgen -skip-master-key | tee wallet.txt
 
 #get wallet addr
 wallet=$(awk '{print $3}' wallet.txt)
@@ -22,17 +22,17 @@ wallet=$(awk '{print $3}' wallet.txt)
 ${PROJECT_DIR}/bin/cql -config ${PROJECT_DIR}/conf/testnet/config.yaml -transfer \
     '{"addr":"'${wallet}'", "amount":"100000000 Particle"}' -wait-tx-confirm
 
-${PROJECT_DIR}/bin/cql -config conf/config.yaml -get-balance
+${PROJECT_DIR}/bin/cql -get-balance
 
-${PROJECT_DIR}/bin/cql -config conf/config.yaml -create 2 -wait-tx-confirm | tee dsn.txt
+${PROJECT_DIR}/bin/cql -create 2 -wait-tx-confirm | tee dsn.txt
 
 #get dsn
 dsn=$(cat dsn.txt)
 
-${PROJECT_DIR}/bin/cql -config conf/config.yaml -dsn ${dsn} \
+${PROJECT_DIR}/bin/cql -dsn ${dsn} \
     -command 'create table test_for_new_account(column1 int);'
 
-${PROJECT_DIR}/bin/cql -config conf/config.yaml -dsn ${dsn} \
+${PROJECT_DIR}/bin/cql -dsn ${dsn} \
     -command 'show tables;' | tee result.log
 
 grep "1 row" result.log

--- a/utils/path.go
+++ b/utils/path.go
@@ -49,13 +49,18 @@ func CopyFile(src, dst string) (int64, error) {
 	return io.Copy(df, sf)
 }
 
-// HomeDirExpand expands the tilde (~) in the front of a path to a the supplied
-// directory.
-func HomeDirExpand(u *user.User, path string) string {
+// HomeDirExpand tries to expand the tilde (~) in the front of a path
+// to a fullpath directory.
+func HomeDirExpand(path string) string {
+	usr, err := user.Current()
+	if err != nil {
+		return path
+	}
+
 	if path == "~" {
-		return u.HomeDir
+		return usr.HomeDir
 	} else if strings.HasPrefix(path, "~/") {
-		return filepath.Join(u.HomeDir, strings.TrimPrefix(path, "~/"))
+		return filepath.Join(usr.HomeDir, strings.TrimPrefix(path, "~/"))
 	}
 
 	return path

--- a/utils/path.go
+++ b/utils/path.go
@@ -19,7 +19,9 @@ package utils
 import (
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strings"
 )
 
 // CopyFile copies from src to dst until either EOF is reached
@@ -45,4 +47,16 @@ func CopyFile(src, dst string) (int64, error) {
 	}
 	defer df.Close()
 	return io.Copy(df, sf)
+}
+
+// HomeDirExpand expands the tilde (~) in the front of a path to a the supplied
+// directory.
+func HomeDirExpand(u *user.User, path string) string {
+	if path == "~" {
+		return u.HomeDir
+	} else if strings.HasPrefix(path, "~/") {
+		return filepath.Join(u.HomeDir, strings.TrimPrefix(path, "~/"))
+	}
+
+	return path
 }

--- a/utils/path_test.go
+++ b/utils/path_test.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -45,5 +46,21 @@ func TestCopyFile(t *testing.T) {
 		n, err = CopyFile("testcopy", "/path/not/exist")
 		So(err, ShouldNotBeNil)
 		So(n, ShouldBeZeroValue)
+	})
+}
+
+func TestHomeDirExpand(t *testing.T) {
+	Convey("expand ~ dir", t, func() {
+		usr, err := user.Current()
+		So(err, ShouldBeNil)
+
+		homeDir := HomeDirExpand(usr, "~")
+		So(homeDir, ShouldEqual, usr.HomeDir)
+
+		fullFilepathWithHome := HomeDirExpand(usr, "~/.local")
+		So(fullFilepathWithHome, ShouldEqual, usr.HomeDir+"/.local")
+
+		fullFilepathRaw := HomeDirExpand(usr, "/dev/null")
+		So(fullFilepathRaw, ShouldEqual, "/dev/null")
 	})
 }

--- a/utils/path_test.go
+++ b/utils/path_test.go
@@ -54,13 +54,13 @@ func TestHomeDirExpand(t *testing.T) {
 		usr, err := user.Current()
 		So(err, ShouldBeNil)
 
-		homeDir := HomeDirExpand(usr, "~")
+		homeDir := HomeDirExpand("~")
 		So(homeDir, ShouldEqual, usr.HomeDir)
 
-		fullFilepathWithHome := HomeDirExpand(usr, "~/.local")
+		fullFilepathWithHome := HomeDirExpand("~/.local")
 		So(fullFilepathWithHome, ShouldEqual, usr.HomeDir+"/.local")
 
-		fullFilepathRaw := HomeDirExpand(usr, "/dev/null")
+		fullFilepathRaw := HomeDirExpand("/dev/null")
 		So(fullFilepathRaw, ShouldEqual, "/dev/null")
 	})
 }

--- a/utils/path_test.go
+++ b/utils/path_test.go
@@ -62,5 +62,8 @@ func TestHomeDirExpand(t *testing.T) {
 
 		fullFilepathRaw := HomeDirExpand("/dev/null")
 		So(fullFilepathRaw, ShouldEqual, "/dev/null")
+
+		emptyPath := HomeDirExpand("")
+		So(emptyPath, ShouldEqual, "")
 	})
 }


### PR DESCRIPTION
1. Change all cmd config param to ~/.cql/config.yaml
2. Config generate will default use ~/.cql/ as well.
3. Driver can reduce client.Init func call if expected using ~/.cql/
4. Update all unit test.
5. Update all README.md
6. Update client example.
7. Compatible with elder usage.
8. Skip compatibility test if branch name contains '/beta_'