### PR TITLE
Combine createRandomBlock functions into one.

### DIFF
--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -19,13 +19,11 @@ package client
 import (
 	"database/sql"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	pi "github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
 	"github.com/CovenantSQL/CovenantSQL/conf"
@@ -143,7 +141,7 @@ func startTestService() (stopTestService func(), tempDir string, err error) {
 	dbID := proto.DatabaseID("db")
 
 	// create sqlchain block
-	block, err = createRandomBlock(rootHash, true)
+	block, err = types.CreateRandomBlock(rootHash, true)
 
 	// get database peers
 	if peers, err = genPeers(1); err != nil {
@@ -264,45 +262,6 @@ func initNode() (cleanupFunc func(), tempDir string, server *rpc.Server, err err
 		atomic.StoreUint32(&driverInitialized, 0)
 		kms.ResetLocalKeyStore()
 	}
-	return
-}
-
-// copied from sqlchain.xxx_test.
-func createRandomBlock(parent hash.Hash, isGenesis bool) (b *types.Block, err error) {
-	// Generate key pair
-	priv, _, err := asymmetric.GenSecp256k1KeyPair()
-
-	if err != nil {
-		return
-	}
-
-	h := hash.Hash{}
-	rand.Read(h[:])
-
-	b = &types.Block{
-		SignedHeader: types.SignedHeader{
-			Header: types.Header{
-				Version:     0x01000000,
-				Producer:    proto.NodeID(h.String()),
-				GenesisHash: rootHash,
-				ParentHash:  parent,
-				Timestamp:   time.Now().UTC(),
-			},
-		},
-	}
-
-	if isGenesis {
-		emptyNode := &proto.RawNodeID{}
-		b.SignedHeader.ParentHash = hash.Hash{}
-		b.SignedHeader.GenesisHash = hash.Hash{}
-		b.SignedHeader.Producer = emptyNode.ToNodeID()
-		b.SignedHeader.MerkleRoot = hash.Hash{}
-
-		err = b.PackAsGenesis()
-		return
-	}
-
-	err = b.PackAndSignBlock(priv)
 	return
 }
 

--- a/sqlchain/xxx_test.go
+++ b/sqlchain/xxx_test.go
@@ -236,26 +236,19 @@ func registerNodesWithPublicKey(pub *asymmetric.PublicKey, diff int, num int) (
 }
 
 func createRandomBlock(parent hash.Hash, isGenesis bool) (b *types.Block, err error) {
-	// Generate key pair
-	priv, _, err := asymmetric.GenSecp256k1KeyPair()
-
+	b, err = types.CreateRandomBlock(parent, isGenesis)
 	if err != nil {
 		return
 	}
 
-	h := hash.Hash{}
-	rand.Read(h[:])
+	if isGenesis {
+		return
+	}
 
-	b = &types.Block{
-		SignedHeader: types.SignedHeader{
-			Header: types.Header{
-				Version:     0x01000000,
-				Producer:    proto.NodeID(h.String()),
-				GenesisHash: genesisHash,
-				ParentHash:  parent,
-				Timestamp:   time.Now().UTC(),
-			},
-		},
+	// Generate key pair
+	priv, _, err := asymmetric.GenSecp256k1KeyPair()
+	if err != nil {
+		return
 	}
 
 	for i, n := 0, rand.Intn(10)+10; i < n; i++ {
@@ -268,18 +261,6 @@ func createRandomBlock(parent hash.Hash, isGenesis bool) (b *types.Block, err er
 				},
 			},
 		}
-	}
-
-	if isGenesis {
-		emptyNode := &proto.RawNodeID{}
-		b.SignedHeader.ParentHash = hash.Hash{}
-		b.SignedHeader.GenesisHash = hash.Hash{}
-		b.SignedHeader.Producer = emptyNode.ToNodeID()
-		b.SignedHeader.MerkleRoot = hash.Hash{}
-		b.Acks = nil
-
-		err = b.PackAsGenesis()
-		return
 	}
 
 	err = b.PackAndSignBlock(priv)

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestSignAndVerify(t *testing.T) {
-	block, err := createRandomBlock(genesisHash, false)
+	block, err := CreateRandomBlock(genesisHash, false)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
@@ -58,7 +58,7 @@ func TestSignAndVerify(t *testing.T) {
 }
 
 func TestHeaderMarshalUnmarshaler(t *testing.T) {
-	block, err := createRandomBlock(genesisHash, false)
+	block, err := CreateRandomBlock(genesisHash, false)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
@@ -96,7 +96,7 @@ func TestHeaderMarshalUnmarshaler(t *testing.T) {
 }
 
 func TestSignedHeaderMarshaleUnmarshaler(t *testing.T) {
-	block, err := createRandomBlock(genesisHash, false)
+	block, err := CreateRandomBlock(genesisHash, false)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
@@ -143,11 +143,11 @@ func TestSignedHeaderMarshaleUnmarshaler(t *testing.T) {
 }
 
 func TestBlockMarshalUnmarshaler(t *testing.T) {
-	origin, err := createRandomBlock(genesisHash, false)
+	origin, err := CreateRandomBlock(genesisHash, false)
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
 	}
-	origin2, err := createRandomBlock(genesisHash, false)
+	origin2, err := CreateRandomBlock(genesisHash, false)
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestBlockMarshalUnmarshaler(t *testing.T) {
 }
 
 func TestGenesis(t *testing.T) {
-	genesis, err := createRandomBlock(genesisHash, true)
+	genesis, err := CreateRandomBlock(genesisHash, true)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
@@ -219,7 +219,7 @@ func TestGenesis(t *testing.T) {
 	}
 
 	// Test non-genesis block
-	genesis, err = createRandomBlock(genesisHash, false)
+	genesis, err = CreateRandomBlock(genesisHash, false)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)
@@ -232,7 +232,7 @@ func TestGenesis(t *testing.T) {
 	}
 
 	// Test altered block
-	genesis, err = createRandomBlock(genesisHash, true)
+	genesis, err = CreateRandomBlock(genesisHash, true)
 
 	if err != nil {
 		t.Fatalf("error occurred: %v", err)

--- a/types/xxx_test.go
+++ b/types/xxx_test.go
@@ -33,7 +33,6 @@ import (
 
 var (
 	uuidLen           = 32
-	genesisHash       = hash.Hash{}
 	testingPrivateKey *asymmetric.PrivateKey
 	testingPublicKey  *asymmetric.PublicKey
 )
@@ -297,44 +296,6 @@ func setup() {
 
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
-}
-
-func createRandomBlock(parent hash.Hash, isGenesis bool) (b *Block, err error) {
-	// Generate key pair
-	priv, _, err := asymmetric.GenSecp256k1KeyPair()
-
-	if err != nil {
-		return
-	}
-
-	h := hash.Hash{}
-	rand.Read(h[:])
-
-	b = &Block{
-		SignedHeader: SignedHeader{
-			Header: Header{
-				Version:     0x01000000,
-				Producer:    proto.NodeID(h.String()),
-				GenesisHash: genesisHash,
-				ParentHash:  parent,
-				Timestamp:   time.Now().UTC(),
-			},
-		},
-	}
-
-	if isGenesis {
-		emptyNode := &proto.RawNodeID{}
-		b.SignedHeader.ParentHash = hash.Hash{}
-		b.SignedHeader.GenesisHash = hash.Hash{}
-		b.SignedHeader.Producer = emptyNode.ToNodeID()
-		b.SignedHeader.MerkleRoot = hash.Hash{}
-
-		err = b.PackAsGenesis()
-		return
-	}
-
-	err = b.PackAndSignBlock(priv)
-	return
 }
 
 func TestMain(m *testing.M) {

--- a/worker/db_test.go
+++ b/worker/db_test.go
@@ -79,7 +79,7 @@ func TestSingleDatabase(t *testing.T) {
 
 		// create genesis block
 		var block *types.Block
-		block, err = createRandomBlock(rootHash, true)
+		block, err = types.CreateRandomBlock(rootHash, true)
 		So(err, ShouldBeNil)
 
 		// create database
@@ -418,7 +418,7 @@ func TestInitFailed(t *testing.T) {
 
 		// create genesis block
 		var block *types.Block
-		block, err = createRandomBlock(rootHash, true)
+		block, err = types.CreateRandomBlock(rootHash, true)
 		So(err, ShouldBeNil)
 
 		// broken peers configuration
@@ -472,7 +472,7 @@ func TestDatabaseRecycle(t *testing.T) {
 
 		// create genesis block
 		var block *types.Block
-		block, err = createRandomBlock(rootHash, true)
+		block, err = types.CreateRandomBlock(rootHash, true)
 		So(err, ShouldBeNil)
 
 		// create database

--- a/worker/dbms_test.go
+++ b/worker/dbms_test.go
@@ -86,7 +86,7 @@ func TestDBMS(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// create sqlchain block
-		block, err = createRandomBlock(rootHash, true)
+		block, err = types.CreateRandomBlock(rootHash, true)
 		So(err, ShouldBeNil)
 
 		// get peers

--- a/worker/helper_test.go
+++ b/worker/helper_test.go
@@ -17,19 +17,16 @@
 package worker
 
 import (
-	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
 	"github.com/CovenantSQL/CovenantSQL/conf"
 	"github.com/CovenantSQL/CovenantSQL/consistent"
-	"github.com/CovenantSQL/CovenantSQL/crypto/asymmetric"
 	"github.com/CovenantSQL/CovenantSQL/crypto/hash"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/route"
@@ -241,44 +238,5 @@ func initNode() (cleanupFunc func(), server *rpc.Server, err error) {
 		rpc.GetSessionPoolInstance().Close()
 	}
 
-	return
-}
-
-// copied from sqlchain.xxx_test.
-func createRandomBlock(parent hash.Hash, isGenesis bool) (b *types.Block, err error) {
-	// Generate key pair
-	priv, _, err := asymmetric.GenSecp256k1KeyPair()
-
-	if err != nil {
-		return
-	}
-
-	h := hash.Hash{}
-	rand.Read(h[:])
-
-	b = &types.Block{
-		SignedHeader: types.SignedHeader{
-			Header: types.Header{
-				Version:     0x01000000,
-				Producer:    proto.NodeID(h.String()),
-				GenesisHash: rootHash,
-				ParentHash:  parent,
-				Timestamp:   time.Now().UTC(),
-			},
-		},
-	}
-
-	if isGenesis {
-		emptyNode := &proto.RawNodeID{}
-		b.SignedHeader.ParentHash = hash.Hash{}
-		b.SignedHeader.GenesisHash = hash.Hash{}
-		b.SignedHeader.Producer = emptyNode.ToNodeID()
-		b.SignedHeader.MerkleRoot = hash.Hash{}
-
-		err = b.PackAsGenesis()
-		return
-	}
-
-	err = b.PackAndSignBlock(priv)
 	return
 }


### PR DESCRIPTION
1. Rename createRandomBlock functions to types.CreateRandomBlock
2. Replace all createRandomBlock to reuse types.CreateRandomBlock
3. Refactor createRandomBlock() in sqlchain/xxx_test.go to reuse types.CreateRandomBlock