### PR TITLE
 Add transaction hash as return value in create/drop

### DIFF
--- a/client/clientbench_test.go
+++ b/client/clientbench_test.go
@@ -66,7 +66,7 @@ func BenchmarkCovenantSQLDriver(b *testing.B) {
 	// create
 	meta := ResourceMeta{}
 	meta.Node = 3
-	dsn, err := Create(meta)
+	_, dsn, err := Create(meta)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func BenchmarkCovenantSQLDriver(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	err = Drop(dsn)
+	_, err = Drop(dsn)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/client/driver.go
+++ b/client/driver.go
@@ -144,8 +144,8 @@ func Init(configFile string, masterKey []byte) (err error) {
 	return
 }
 
-// Create send create database operation to block producer.
-func Create(meta ResourceMeta) (dsn string, err error) {
+// Create sends create database operation to block producer.
+func Create(meta ResourceMeta) (txHash hash.Hash, dsn string, err error) {
 	if atomic.LoadUint32(&driverInitialized) == 0 {
 		err = ErrNotInitialized
 		return
@@ -202,6 +202,7 @@ func Create(meta ResourceMeta) (dsn string, err error) {
 		return
 	}
 
+	txHash = req.Tx.Hash()
 	cfg := NewConfig()
 	cfg.DatabaseID = string(proto.FromAccountAndNonce(clientAddr, uint32(nonceResp.Nonce)))
 	dsn = cfg.FormatDSN()
@@ -269,7 +270,7 @@ func WaitBPDatabaseCreation(
 }
 
 // Drop send drop database operation to block producer.
-func Drop(dsn string) (err error) {
+func Drop(dsn string) (txHash hash.Hash, err error) {
 	if atomic.LoadUint32(&driverInitialized) == 0 {
 		err = ErrNotInitialized
 		return

--- a/client/driver.go
+++ b/client/driver.go
@@ -269,7 +269,7 @@ func WaitBPDatabaseCreation(
 	}
 }
 
-// Drop send drop database operation to block producer.
+// Drop sends drop database operation to block producer.
 func Drop(dsn string) (txHash hash.Hash, err error) {
 	if atomic.LoadUint32(&driverInitialized) == 0 {
 		err = ErrNotInitialized

--- a/client/driver_test.go
+++ b/client/driver_test.go
@@ -118,12 +118,12 @@ func TestCreate(t *testing.T) {
 		var err error
 		var dsn string
 
-		dsn, err = Create(ResourceMeta{})
+		_, dsn, err = Create(ResourceMeta{})
 		So(err, ShouldEqual, ErrNotInitialized)
 
 		// fake driver initialized
 		atomic.StoreUint32(&driverInitialized, 1)
-		dsn, err = Create(ResourceMeta{})
+		_, dsn, err = Create(ResourceMeta{})
 		So(err, ShouldNotBeNil)
 		// reset driver not initialized
 		atomic.StoreUint32(&driverInitialized, 0)
@@ -131,7 +131,7 @@ func TestCreate(t *testing.T) {
 		stopTestService, _, err = startTestService()
 		So(err, ShouldBeNil)
 		defer stopTestService()
-		dsn, err = Create(ResourceMeta{})
+		_, dsn, err = Create(ResourceMeta{})
 		So(err, ShouldBeNil)
 		dsnCfg, err := ParseDSN(dsn)
 		So(err, ShouldBeNil)
@@ -171,16 +171,16 @@ func TestDrop(t *testing.T) {
 		var stopTestService func()
 		var err error
 
-		err = Drop("covenantsql://db")
+		_, err = Drop("covenantsql://db")
 		So(err, ShouldEqual, ErrNotInitialized)
 
 		stopTestService, _, err = startTestService()
 		So(err, ShouldBeNil)
 		defer stopTestService()
-		err = Drop("covenantsql://db")
+		_, err = Drop("covenantsql://db")
 		So(err, ShouldBeNil)
 
-		err = Drop("invalid dsn")
+		_, err = Drop("invalid dsn")
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -259,7 +259,7 @@ func TestWaitDBCreation(t *testing.T) {
 		err = WaitDBCreation(ctx, "covenantsql://db")
 		So(err, ShouldBeNil)
 
-		dsn, err = Create(ResourceMeta{})
+		_, dsn, err = Create(ResourceMeta{})
 		So(err, ShouldBeNil)
 		err = WaitDBCreation(ctx, dsn)
 		So(err, ShouldNotBeNil)

--- a/cmd/cql-adapter/storage/covenantsql.go
+++ b/cmd/cql-adapter/storage/covenantsql.go
@@ -37,7 +37,7 @@ func (s *CovenantSQLStorage) Create(nodeCnt int) (dbID string, err error) {
 	meta.Node = uint16(nodeCnt)
 
 	var dsn string
-	if dsn, err = client.Create(meta); err != nil {
+	if _, dsn, err = client.Create(meta); err != nil {
 		return
 	}
 
@@ -54,7 +54,7 @@ func (s *CovenantSQLStorage) Create(nodeCnt int) (dbID string, err error) {
 func (s *CovenantSQLStorage) Drop(dbID string) (err error) {
 	cfg := client.NewConfig()
 	cfg.DatabaseID = dbID
-	err = client.Drop(cfg.FormatDSN())
+	_, err = client.Drop(cfg.FormatDSN())
 	return
 }
 

--- a/cmd/cql-fuse/block_test.go
+++ b/cmd/cql-fuse/block_test.go
@@ -256,7 +256,7 @@ func initTestDB() (*sql.DB, func()) {
 	// create
 	meta := client.ResourceMeta{}
 	meta.Node = 1
-	dsn, err := client.Create(meta)
+	_, dsn, err := client.Create(meta)
 	if err != nil {
 		log.Errorf("create db failed: %v", err)
 		return nil, stopNodes

--- a/cmd/cql-minerd/integration_test.go
+++ b/cmd/cql-minerd/integration_test.go
@@ -395,7 +395,7 @@ func TestFullProcess(t *testing.T) {
 			t.Fatalf("wait for chain service failed: %v", err)
 		}
 
-		dsn, err := client.Create(meta)
+		_, dsn, err := client.Create(meta)
 		So(err, ShouldBeNil)
 		dsnCfg, err := client.ParseDSN(dsn)
 		So(err, ShouldBeNil)
@@ -769,7 +769,7 @@ func benchMiner(b *testing.B, minerCount uint16, bypassSign bool, useEventualCon
 		// create
 		meta := client.ResourceMeta{
 			ResourceMeta: types.ResourceMeta{
-				Node:                   minerCount,
+				Node: minerCount,
 				UseEventualConsistency: useEventualConsistency,
 			},
 		}
@@ -781,7 +781,7 @@ func benchMiner(b *testing.B, minerCount uint16, bypassSign bool, useEventualCon
 			b.Fatalf("wait for chain service failed: %v", err)
 		}
 
-		dsn, err = client.Create(meta)
+		_, dsn, err = client.Create(meta)
 		So(err, ShouldBeNil)
 		log.Infof("the created database dsn is %v", dsn)
 		err = ioutil.WriteFile(dsnFile, []byte(dsn), 0666)
@@ -804,7 +804,7 @@ func benchMiner(b *testing.B, minerCount uint16, bypassSign bool, useEventualCon
 
 	benchDB(b, db, minerCount > 0)
 
-	err = client.Drop(dsn)
+	_, err = client.Drop(dsn)
 	So(err, ShouldBeNil)
 	time.Sleep(5 * time.Second)
 	stopNodes()
@@ -892,7 +892,7 @@ func benchOutsideMinerWithTargetMinerList(
 			b.Fatalf("wait for chain service failed: %v", err)
 		}
 
-		dsn, err = client.Create(meta)
+		_, dsn, err = client.Create(meta)
 		So(err, ShouldBeNil)
 		log.Infof("the created database dsn is %v", dsn)
 

--- a/cmd/cql-observer/observation_test.go
+++ b/cmd/cql-observer/observation_test.go
@@ -696,10 +696,10 @@ func TestFullProcess(t *testing.T) {
 		So(ensureSuccess(res.Int("block", "height")), ShouldBeGreaterThanOrEqualTo, 0)
 		log.Info(err, res)
 
-		err = client.Drop(dsn)
+		_, err = client.Drop(dsn)
 		So(err, ShouldBeNil)
 
-		err = client.Drop(dsn2)
+		_, err = client.Drop(dsn2)
 		So(err, ShouldBeNil)
 
 		observerCmd.Cmd.Process.Signal(os.Interrupt)

--- a/cmd/cql/main.go
+++ b/cmd/cql/main.go
@@ -360,6 +360,13 @@ func main() {
 
 		if waitTxConfirmation {
 			wait(txHash)
+			var ctx, cancel = context.WithTimeout(context.Background(), waitTxConfirmationMaxDuration)
+			defer cancel()
+			err = client.WaitDBCreation(ctx, dsn)
+			if err != nil {
+				log.WithError(err).Error("wait database failed during creation")
+				os.Exit(-1)
+			}
 		}
 
 		log.Infof("the newly created database is: %#v", dsn)


### PR DESCRIPTION
Now, `cql` tool can use the returned hash to check transaction status.