### PR TITLE
Fix connection leak

### DIFF
--- a/kayak/utils.go
+++ b/kayak/utils.go
@@ -25,8 +25,12 @@ import (
 )
 
 func (r *Runtime) getCaller(id proto.NodeID) Caller {
-	var caller Caller = rpc.NewPersistentCaller(id)
-	rawCaller, _ := r.callerMap.LoadOrStore(id, caller)
+	pcaller := rpc.NewPersistentCaller(id)
+	caller := pcaller
+	rawCaller, loaded := r.callerMap.LoadOrStore(id, caller)
+	if loaded {
+		pcaller.Close()
+	}
 	return rawCaller.(Caller)
 }
 


### PR DESCRIPTION
The persistent caller borrows rpc.Client from pool and returns it to upon closing. NewPersistentCaller call without close will cause connection leak.