### PR TITLE
Lower memory consumption while rebuilding chain

### DIFF
--- a/blockproducer/blocknode.go
+++ b/blockproducer/blocknode.go
@@ -53,6 +53,13 @@ func newBlockNode(h uint32, b *types.BPBlock, p *blockNode) (node *blockNode) {
 	return
 }
 
+// newNonCacheBlockNode returns a block node without the *types.BPBlock cached.
+func newNonCacheBlockNode(h uint32, b *types.BPBlock, p *blockNode) (node *blockNode) {
+	node = newBlockNode(h, b, p)
+	node.clear()
+	return
+}
+
 func (n *blockNode) load() *types.BPBlock {
 	return n.block.Load().(*types.BPBlock)
 }

--- a/blockproducer/chain_io.go
+++ b/blockproducer/chain_io.go
@@ -21,7 +21,6 @@ import (
 	"github.com/CovenantSQL/CovenantSQL/crypto/hash"
 	"github.com/CovenantSQL/CovenantSQL/proto"
 	"github.com/CovenantSQL/CovenantSQL/types"
-	"github.com/CovenantSQL/CovenantSQL/utils"
 	"github.com/CovenantSQL/CovenantSQL/utils/log"
 )
 
@@ -29,20 +28,7 @@ import (
 
 // loadBlock loads a BPBlock from chain storage.
 func (c *Chain) loadBlock(h hash.Hash) (b *types.BPBlock, err error) {
-	var (
-		enc []byte
-		out = &types.BPBlock{}
-	)
-	if err = c.storage.Reader().QueryRow(
-		`SELECT "encoded" FROM "blocks" WHERE "hash"=?`, h.String(),
-	).Scan(&enc); err != nil {
-		return
-	}
-	if err = utils.DecodeMsgPack(enc, out); err != nil {
-		return
-	}
-	b = out
-	return
+	return loadBlock(c.storage, h)
 }
 
 func (c *Chain) fetchLastIrreversibleBlock() (


### PR DESCRIPTION
In the former implementation, the chain reads every block from the storage to rebuild branches. This will cost higher and higher memory consumption with the increase of chain height.
Note that it uses the persistent immutable state, which is the state snapshot of the last irreversible block, as a base, and replays any successive block to rebuild the branch state. So actually only the blocks after the last irreversible block, aka the reversible blocks, are needed here. Hence here comes this fix.