### PR TITLE
Remove the initialization BP step

### DIFF
--- a/cmd/cql-minerd/node.go
+++ b/cmd/cql-minerd/node.go
@@ -61,7 +61,6 @@ func initNode() (server *mux.Server, direct *rpc.Server, err error) {
 
 	// init kms routing
 	route.InitKMS(conf.GConf.PubKeyStoreFile)
-	kms.InitBP()
 
 	err = mux.RegisterNodeToBP(30 * time.Second)
 	if err != nil {


### PR DESCRIPTION
Remove the initialization BP because it was included when KMS was initialized