### PR TITLE
Fix SQLChain initiating issue

### DIFF
--- a/client/driver.go
+++ b/client/driver.go
@@ -292,7 +292,10 @@ func WaitBPDatabaseCreation(
 			}
 			fmt.Printf("\rQuerying SQLChain Profile %vs", count*int(period.Seconds()))
 		case <-ctx.Done():
-			return errors.Wrapf(ctx.Err(), "last error: %s", err.Error())
+			if err != nil {
+				return errors.Wrapf(ctx.Err(), "last error: %s", err.Error())
+			}
+			return ctx.Err()
 		}
 	}
 }

--- a/client/driver.go
+++ b/client/driver.go
@@ -292,8 +292,7 @@ func WaitBPDatabaseCreation(
 			}
 			fmt.Printf("\rQuerying SQLChain Profile %vs", count*int(period.Seconds()))
 		case <-ctx.Done():
-			err = errors.New(err.Error() + ctx.Err().Error())
-			return
+			return errors.Wrapf(ctx.Err(), "last error: %s", err.Error())
 		}
 	}
 }

--- a/client/driver.go
+++ b/client/driver.go
@@ -292,7 +292,7 @@ func WaitBPDatabaseCreation(
 			}
 			fmt.Printf("\rQuerying SQLChain Profile %vs", count*int(period.Seconds()))
 		case <-ctx.Done():
-			err = ctx.Err()
+			err = errors.New(err.Error() + ctx.Err().Error())
 			return
 		}
 	}

--- a/cmd/cql/internal/create.go
+++ b/cmd/cql/internal/create.go
@@ -186,6 +186,7 @@ func runCreate(cmd *Command, args []string) {
 			SetExitStatus(1)
 			return
 		}
+		fmt.Printf("\nThe database is accecpted by blockproducer, DSN: %#v\n", dsn)
 
 		var ctx, cancel = context.WithTimeout(context.Background(), waitTxConfirmationMaxDuration)
 		defer cancel()
@@ -197,7 +198,7 @@ func runCreate(cmd *Command, args []string) {
 		}
 	}
 
-	fmt.Printf("\nThe newly created database is: %#v\n", dsn)
+	fmt.Printf("\nThe database is created on miners, DSN: %#v\n", dsn)
 	storeOneDSN(dsn)
 	fmt.Printf("The connecting string beginning with 'covenantsql://' could be used as a dsn for `cql console`\n or any command, or be used in website like https://web.covenantsql.io\n")
 }

--- a/sqlchain/chain.go
+++ b/sqlchain/chain.go
@@ -623,12 +623,13 @@ func (c *Chain) syncHead() (err error) {
 				return
 			}
 
-			atomic.AddUint32(&succCount, 1)
 			if resp.Block == nil {
 				ile.Debug("fetch block request reply: no such block")
 				// If block is nil, resp.Height returns the current head height of the remote peer
 				if resp.Height <= req.Height {
 					atomic.AddUint32(&initiatingCount, 1)
+				} else {
+					atomic.AddUint32(&succCount, 1)
 				}
 				return
 			}

--- a/sqlchain/chain.go
+++ b/sqlchain/chain.go
@@ -730,7 +730,9 @@ func (c *Chain) sync() (err error) {
 					le.WithError(err).Errorf("failed to sync block at height %d", height)
 					return
 				}
+				// Skip sync and reset error
 				c.rt.SetNextTurn(height + 1)
+				err = nil
 			} else {
 				c.rt.IncNextTurn()
 			}

--- a/sqlchain/chain.go
+++ b/sqlchain/chain.go
@@ -640,6 +640,7 @@ func (c *Chain) syncHead() (err error) {
 			}).Debug("fetch block request reply: found block")
 			select {
 			case c.blocks <- resp.Block:
+				atomic.AddUint32(&succCount, 1)
 			case <-child.Done():
 				le.WithError(child.Err()).Info("abort head block synchronizing")
 				return

--- a/sqlchain/chain.go
+++ b/sqlchain/chain.go
@@ -693,7 +693,9 @@ func (c *Chain) mainCycle(ctx context.Context) {
 			return
 		default:
 			if err := c.syncHead(); err != nil {
-				c.logEntry().WithError(err).Error("failed to sync head")
+				if err != ErrInitiating {
+					c.logEntry().WithError(err).Error("failed to sync head")
+				}
 				continue
 			}
 			if t, d := c.rt.nextTick(); d > 0 {

--- a/sqlchain/chain.go
+++ b/sqlchain/chain.go
@@ -670,7 +670,7 @@ func (c *Chain) runCurrentTurn(now time.Time, d time.Duration) {
 
 	le.Debug("run current turn")
 	if c.rt.getHead().Height < c.rt.getNextTurn()-1 {
-		le.Error("a block will be skipped")
+		le.Debug("a block will be skipped")
 	}
 	if !c.rt.isMyTurn() {
 		return

--- a/sqlchain/errors.go
+++ b/sqlchain/errors.go
@@ -42,4 +42,7 @@ var (
 	// ErrResponseSeqNotMatch indicates that a response sequence id doesn't match the original one
 	// in the index.
 	ErrResponseSeqNotMatch = errors.New("response sequence id doesn't match")
+	// ErrInitiating indicates that a sqlchain is in initiate state and is not available for sync
+	// requests.
+	ErrInitiating = errors.New("sqlchain is in initiate")
 )

--- a/sqlchain/rpc.go
+++ b/sqlchain/rpc.go
@@ -57,5 +57,8 @@ func (s *ChainRPCService) AdviseNewBlock(req *AdviseNewBlockReq, resp *AdviseNew
 func (s *ChainRPCService) FetchBlock(req *FetchBlockReq, resp *FetchBlockResp) (err error) {
 	resp.Height = req.Height
 	resp.Block, err = s.chain.FetchBlock(req.Height)
+	if err == nil && resp.Block == nil {
+		resp.Height = s.chain.getCurrentHeight()
+	}
 	return
 }

--- a/sqlchain/runtime.go
+++ b/sqlchain/runtime.go
@@ -196,11 +196,18 @@ func (r *runtime) getNextTurn() int32 {
 	return r.nextTurn
 }
 
-// setNextTurn prepares the runtime state for the next turn.
-func (r *runtime) setNextTurn() {
+// IncNextTurn prepares the runtime state for the next turn.
+func (r *runtime) IncNextTurn() {
 	r.stateMutex.Lock()
 	defer r.stateMutex.Unlock()
 	r.nextTurn++
+}
+
+// SetNextTurn sets the runtime state to the given turn.
+func (r *runtime) SetNextTurn(turn int32) {
+	r.stateMutex.Lock()
+	defer r.stateMutex.Unlock()
+	r.nextTurn = turn
 }
 
 // stop sends a signal to the Runtime stop channel by closing it.

--- a/worker/dbms.go
+++ b/worker/dbms.go
@@ -375,7 +375,6 @@ func (dbms *DBMS) initDatabases(
 ) {
 	currentInstance := make(map[proto.DatabaseID]bool)
 	wg := &sync.WaitGroup{}
-	errCh := make(chan error, len(profiles))
 
 	for id, profile := range profiles {
 		currentInstance[id] = true
@@ -390,15 +389,10 @@ func (dbms *DBMS) initDatabases(
 				log.WithFields(log.Fields{
 					"id": instance.DatabaseID,
 				}).WithError(err).Error("failed to create database instance")
-				errCh <- errors.Wrapf(err, "failed to create database %s", instance.DatabaseID)
 			}
 		}()
 	}
 	wg.Wait()
-	close(errCh)
-	for err := range errCh {
-		return err // omit any other error after this instance
-	}
 
 	// calculate to drop databases
 	toDropInstance := make(map[proto.DatabaseID]bool)

--- a/worker/dbms.go
+++ b/worker/dbms.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	mw "github.com/zserge/metric"
 
 	"github.com/CovenantSQL/CovenantSQL/blockproducer/interfaces"
 	"github.com/CovenantSQL/CovenantSQL/conf"
@@ -56,7 +55,7 @@ const (
 )
 
 var (
-	dbCount = mw.NewCounter("5m1m")
+	dbCount = new(expvar.Int)
 )
 
 func init() {

--- a/worker/dbms.go
+++ b/worker/dbms.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -57,7 +56,7 @@ const (
 )
 
 var (
-	dbCount = mw.NewGauge("5m1m")
+	dbCount = mw.NewCounter("5m1m")
 )
 
 func init() {
@@ -68,7 +67,6 @@ func init() {
 type DBMS struct {
 	cfg        *DBMSConfig
 	dbMap      sync.Map
-	dbCount    int64
 	kayakMux   *DBKayakMuxService
 	chainMux   *sqlchain.MuxService
 	rpc        *DBMSRPCService
@@ -472,7 +470,7 @@ func (dbms *DBMS) Create(instance *types.ServiceInstance, cleanup bool) (err err
 	err = dbms.addMeta(instance.DatabaseID, db)
 
 	// update metrics
-	dbCount.Add(float64(atomic.AddInt64(&dbms.dbCount, 1)))
+	dbCount.Add(1)
 
 	return
 }
@@ -492,7 +490,7 @@ func (dbms *DBMS) Drop(dbID proto.DatabaseID) (err error) {
 	}
 
 	// update metrics
-	dbCount.Add(float64(atomic.AddInt64(&dbms.dbCount, -1)))
+	dbCount.Add(-1)
 
 	// remove meta
 	return dbms.removeMeta(dbID)


### PR DESCRIPTION
- Reuse the FetchBlock protocol to indicate the current height
- Support fast-forward block syncing in chain initiating
- Database initialization error does NOT cause miner process to quit （however this needs some further work to correct the server behavior)
- Other fixes